### PR TITLE
fix: bool and none equality

### DIFF
--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__bool_add_error.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__bool_add_error.snap
@@ -1,0 +1,10 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+true + false
+
+
+# Result:
+runtime error: cannot `+` `bool`

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__bool_div_error.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__bool_div_error.snap
@@ -1,0 +1,10 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+true / false
+
+
+# Result:
+runtime error: cannot `/` `bool`

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__bool_equality.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__bool_equality.snap
@@ -1,0 +1,19 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+a := true
+b := false
+if a == b:
+  print "a == b"
+if a != b:
+  print "a != b"
+
+
+# Result:
+None
+
+# Output:
+a != b
+

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__bool_ge_error.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__bool_ge_error.snap
@@ -1,0 +1,10 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+true >= false
+
+
+# Result:
+runtime error: cannot `>=` `bool`

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__bool_gt_error.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__bool_gt_error.snap
@@ -1,0 +1,10 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+true > false
+
+
+# Result:
+runtime error: cannot `>` `bool`

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__bool_le_error.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__bool_le_error.snap
@@ -1,0 +1,10 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+true <= false
+
+
+# Result:
+runtime error: cannot `<=` `bool`

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__bool_lt_error.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__bool_lt_error.snap
@@ -1,0 +1,10 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+true < false
+
+
+# Result:
+runtime error: cannot `<` `bool`

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__bool_mul_error.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__bool_mul_error.snap
@@ -1,0 +1,10 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+true * false
+
+
+# Result:
+runtime error: cannot `*` `bool`

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__bool_pow_error.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__bool_pow_error.snap
@@ -1,0 +1,10 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+true ** false
+
+
+# Result:
+runtime error: cannot `**` `bool`

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__bool_rem_error.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__bool_rem_error.snap
@@ -1,0 +1,10 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+true % false
+
+
+# Result:
+runtime error: cannot `%` `bool`

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__bool_sub_error.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__bool_sub_error.snap
@@ -1,0 +1,10 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+true - false
+
+
+# Result:
+runtime error: cannot `-` `bool`

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__none_add_error.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__none_add_error.snap
@@ -1,0 +1,10 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+none + none
+
+
+# Result:
+runtime error: cannot `+` `none`

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__none_div_error.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__none_div_error.snap
@@ -1,0 +1,10 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+none / none
+
+
+# Result:
+runtime error: cannot `/` `none`

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__none_equality.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__none_equality.snap
@@ -1,0 +1,18 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+a := none
+if a == none:
+  print "a == none"
+if a != none:
+  print "a != none"
+
+
+# Result:
+None
+
+# Output:
+a == none
+

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__none_ge_error.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__none_ge_error.snap
@@ -1,0 +1,10 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+none >= none
+
+
+# Result:
+runtime error: cannot `>=` `none`

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__none_gt_error.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__none_gt_error.snap
@@ -1,0 +1,10 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+none > none
+
+
+# Result:
+runtime error: cannot `>` `none`

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__none_le_error.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__none_le_error.snap
@@ -1,0 +1,10 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+none <= none
+
+
+# Result:
+runtime error: cannot `<=` `none`

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__none_lt_error.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__none_lt_error.snap
@@ -1,0 +1,10 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+none < none
+
+
+# Result:
+runtime error: cannot `<` `none`

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__none_mul_error.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__none_mul_error.snap
@@ -1,0 +1,10 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+none * none
+
+
+# Result:
+runtime error: cannot `*` `none`

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__none_pow_error.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__none_pow_error.snap
@@ -1,0 +1,10 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+none ** none
+
+
+# Result:
+runtime error: cannot `**` `none`

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__none_rem_error.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__none_rem_error.snap
@@ -1,0 +1,10 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+none % none
+
+
+# Result:
+runtime error: cannot `%` `none`

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__none_sub_error.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__none_sub_error.snap
@@ -1,0 +1,10 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+none - none
+
+
+# Result:
+runtime error: cannot `-` `none`

--- a/src/internal/vm/tests.rs
+++ b/src/internal/vm/tests.rs
@@ -1633,3 +1633,26 @@ check! {
     print (a + f())
   "#
 }
+
+check! {
+  bool_equality,
+  r#"#!hebi
+    a := true
+    b := false
+    if a == b:
+      print "a == b"
+    if a != b:
+      print "a != b"
+  "#
+}
+
+check! {
+  none_equality,
+  r#"#!hebi
+    a := none
+    if a == none:
+      print "a == none"
+    if a != none:
+      print "a != none"
+  "#
+}

--- a/src/internal/vm/tests.rs
+++ b/src/internal/vm/tests.rs
@@ -1656,3 +1656,143 @@ check! {
       print "a != none"
   "#
 }
+
+check! {
+  bool_add_error,
+  r#"#!hebi
+    true + false
+  "#
+}
+
+check! {
+  none_add_error,
+  r#"#!hebi
+    none + none
+  "#
+}
+
+check! {
+  bool_sub_error,
+  r#"#!hebi
+    true - false
+  "#
+}
+
+check! {
+  none_sub_error,
+  r#"#!hebi
+    none - none
+  "#
+}
+
+check! {
+  bool_mul_error,
+  r#"#!hebi
+    true * false
+  "#
+}
+
+check! {
+  none_mul_error,
+  r#"#!hebi
+    none * none
+  "#
+}
+
+check! {
+  bool_div_error,
+  r#"#!hebi
+    true / false
+  "#
+}
+
+check! {
+  none_div_error,
+  r#"#!hebi
+    none / none
+  "#
+}
+
+check! {
+  bool_rem_error,
+  r#"#!hebi
+    true % false
+  "#
+}
+
+check! {
+  none_rem_error,
+  r#"#!hebi
+    none % none
+  "#
+}
+
+check! {
+  bool_pow_error,
+  r#"#!hebi
+    true ** false
+  "#
+}
+
+check! {
+  none_pow_error,
+  r#"#!hebi
+    none ** none
+  "#
+}
+
+check! {
+  bool_gt_error,
+  r#"#!hebi
+    true > false
+  "#
+}
+
+check! {
+  none_gt_error,
+  r#"#!hebi
+    none > none
+  "#
+}
+
+check! {
+  bool_ge_error,
+  r#"#!hebi
+    true >= false
+  "#
+}
+
+check! {
+  none_ge_error,
+  r#"#!hebi
+    none >= none
+  "#
+}
+
+check! {
+  bool_lt_error,
+  r#"#!hebi
+    true < false
+  "#
+}
+
+check! {
+  none_lt_error,
+  r#"#!hebi
+    none < none
+  "#
+}
+
+check! {
+  bool_le_error,
+  r#"#!hebi
+    true <= false
+  "#
+}
+
+check! {
+  none_le_error,
+  r#"#!hebi
+    none <= none
+  "#
+}

--- a/src/internal/vm/thread.rs
+++ b/src/internal/vm/thread.rs
@@ -1210,6 +1210,8 @@ impl Handler for Thread {
       i32 => Value::bool(lhs == rhs),
       f64 => Value::bool(lhs == rhs),
       any => Value::bool(matches!(lhs.cmp(self.get_empty_scope(), rhs)?, Ordering::Equal)),
+      bool => Value::bool(lhs == rhs),
+      none => Value::bool(true)
     });
     self.acc = value;
     Ok(())
@@ -1225,6 +1227,8 @@ impl Handler for Thread {
       i32 => Value::bool(lhs != rhs),
       f64 => Value::bool(lhs != rhs),
       any => Value::bool(!matches!(lhs.cmp(self.get_empty_scope(), rhs)?, Ordering::Equal)),
+      bool => Value::bool(lhs != rhs),
+      none => Value::bool(false)
     });
     self.acc = value;
     Ok(())

--- a/src/internal/vm/thread.rs
+++ b/src/internal/vm/thread.rs
@@ -1070,7 +1070,7 @@ impl Handler for Thread {
 
     let lhs = self.get_register(lhs);
     let rhs = take(&mut self.acc);
-    let value = binary!(lhs, rhs {
+    let value = binary!(lhs + rhs {
       i32 => Value::int(lhs + rhs),
       f64 => Value::float(lhs + rhs),
       any => lhs.add(self.get_empty_scope(), rhs)?,
@@ -1085,7 +1085,7 @@ impl Handler for Thread {
 
     let lhs = self.get_register(lhs);
     let rhs = take(&mut self.acc);
-    let value = binary!(lhs, rhs {
+    let value = binary!(lhs - rhs {
       i32 => Value::int(lhs - rhs),
       f64 => Value::float(lhs - rhs),
       any => lhs.subtract(self.get_empty_scope(), rhs)?,
@@ -1100,7 +1100,7 @@ impl Handler for Thread {
 
     let lhs = self.get_register(lhs);
     let rhs = take(&mut self.acc);
-    let value = binary!(lhs, rhs {
+    let value = binary!(lhs * rhs {
       i32 => Value::int(lhs * rhs),
       f64 => Value::float(lhs * rhs),
       any => lhs.multiply(self.get_empty_scope(), rhs)?,
@@ -1115,7 +1115,7 @@ impl Handler for Thread {
 
     let lhs = self.get_register(lhs);
     let rhs = take(&mut self.acc);
-    let value = binary!(lhs, rhs {
+    let value = binary!(lhs / rhs {
       i32 => {
         if rhs != 0 {
           Value::float(lhs as f64 / rhs as f64)
@@ -1136,7 +1136,7 @@ impl Handler for Thread {
 
     let lhs = self.get_register(lhs);
     let rhs = take(&mut self.acc);
-    let value = binary!(lhs, rhs {
+    let value = binary!(lhs % rhs {
       i32 => {
         if rhs != 0 {
           Value::float(lhs as f64 % rhs as f64)
@@ -1157,7 +1157,7 @@ impl Handler for Thread {
 
     let lhs = self.get_register(lhs);
     let rhs = take(&mut self.acc);
-    let value = binary!(lhs, rhs {
+    let value = binary!(lhs ** rhs {
       i32 => Value::float((lhs as f64).powf(rhs as f64)),
       f64 => Value::float(lhs.powf(rhs)),
       any => lhs.pow(self.get_empty_scope(), rhs)?,
@@ -1211,7 +1211,7 @@ impl Handler for Thread {
       f64 => Value::bool(lhs == rhs),
       any => Value::bool(matches!(lhs.cmp(self.get_empty_scope(), rhs)?, Ordering::Equal)),
       bool => Value::bool(lhs == rhs),
-      none => Value::bool(true)
+      none => Value::bool(true),
     });
     self.acc = value;
     Ok(())
@@ -1228,7 +1228,7 @@ impl Handler for Thread {
       f64 => Value::bool(lhs != rhs),
       any => Value::bool(!matches!(lhs.cmp(self.get_empty_scope(), rhs)?, Ordering::Equal)),
       bool => Value::bool(lhs != rhs),
-      none => Value::bool(false)
+      none => Value::bool(false),
     });
     self.acc = value;
     Ok(())
@@ -1240,7 +1240,7 @@ impl Handler for Thread {
 
     let lhs = self.get_register(lhs);
     let rhs = take(&mut self.acc);
-    let value = binary!(lhs, rhs {
+    let value = binary!(lhs > rhs {
       i32 => Value::bool(lhs > rhs),
       f64 => Value::bool(lhs > rhs),
       any => Value::bool(matches!(lhs.cmp(self.get_empty_scope(), rhs)?, Ordering::Greater)),
@@ -1255,7 +1255,7 @@ impl Handler for Thread {
 
     let lhs = self.get_register(lhs);
     let rhs = take(&mut self.acc);
-    let value = binary!(lhs, rhs {
+    let value = binary!(lhs >= rhs {
       i32 => Value::bool(lhs >= rhs),
       f64 => Value::bool(lhs >= rhs),
       any => Value::bool(matches!(lhs.cmp(self.get_empty_scope(), rhs)?, Ordering::Greater | Ordering::Equal)),
@@ -1270,7 +1270,7 @@ impl Handler for Thread {
 
     let lhs = self.get_register(lhs);
     let rhs = take(&mut self.acc);
-    let value = binary!(lhs, rhs {
+    let value = binary!(lhs < rhs {
       i32 => Value::bool(lhs < rhs),
       f64 => Value::bool(lhs < rhs),
       any => Value::bool(matches!(lhs.cmp(self.get_empty_scope(), rhs)?, Ordering::Less)),
@@ -1285,7 +1285,7 @@ impl Handler for Thread {
 
     let lhs = self.get_register(lhs);
     let rhs = take(&mut self.acc);
-    let value = binary!(lhs, rhs {
+    let value = binary!(lhs <= rhs {
       i32 => Value::bool(lhs <= rhs),
       f64 => Value::bool(lhs <= rhs),
       any => Value::bool(matches!(lhs.cmp(self.get_empty_scope(), rhs)?, Ordering::Less | Ordering::Equal)),

--- a/src/internal/vm/thread/macros.rs
+++ b/src/internal/vm/thread/macros.rs
@@ -51,7 +51,20 @@ macro_rules! current_call_frame_mut {
 }
 
 macro_rules! binary {
-  ($lhs:ident, $rhs:ident {
+  ($lhs:ident ** $rhs:ident {
+    i32 => $i32_expr:expr,
+    f64 => $f64_expr:expr,
+    any => $any_expr:expr,
+  }) => {{
+    binary!($lhs, $rhs {
+      i32 => $i32_expr,
+      f64 => $f64_expr,
+      any => $any_expr,
+      bool => fail!("cannot `**` `bool`"),
+      none => fail!("cannot `**` `none`"),
+    })
+  }};
+  ($lhs:ident $op:tt $rhs:ident {
     i32 => $i32_expr:expr,
     f64 => $f64_expr:expr,
     any => $any_expr:expr,
@@ -61,7 +74,7 @@ macro_rules! binary {
       f64 => $f64_expr,
       any => $any_expr,
       bool => fail!("cannot `{}` `bool`", stringify!($op)),
-      none => fail!("cannot `{}` `none`", stringify!($op))
+      none => fail!("cannot `{}` `none`", stringify!($op)),
     })
   }};
   ($lhs:ident, $rhs:ident {
@@ -69,7 +82,7 @@ macro_rules! binary {
     f64 => $f64_expr:expr,
     any => $any_expr:expr,
     bool => $bool_expr:expr,
-    none => $none_expr:expr
+    none => $none_expr:expr,
   }) => {{
     if $lhs.is_int() && $rhs.is_int() {
       let $lhs = unsafe { $lhs.to_int_unchecked() };

--- a/src/internal/vm/thread/macros.rs
+++ b/src/internal/vm/thread/macros.rs
@@ -56,6 +56,21 @@ macro_rules! binary {
     f64 => $f64_expr:expr,
     any => $any_expr:expr,
   }) => {{
+    binary!($lhs, $rhs {
+      i32 => $i32_expr,
+      f64 => $f64_expr,
+      any => $any_expr,
+      bool => fail!("cannot `{}` `bool`", stringify!($op)),
+      none => fail!("cannot `{}` `none`", stringify!($op))
+    })
+  }};
+  ($lhs:ident, $rhs:ident {
+    i32 => $i32_expr:expr,
+    f64 => $f64_expr:expr,
+    any => $any_expr:expr,
+    bool => $bool_expr:expr,
+    none => $none_expr:expr
+  }) => {{
     if $lhs.is_int() && $rhs.is_int() {
       let $lhs = unsafe { $lhs.to_int_unchecked() };
       let $rhs = unsafe { $rhs.to_int_unchecked() };
@@ -73,9 +88,13 @@ macro_rules! binary {
       let $rhs = unsafe { $rhs.to_float_unchecked() };
       $f64_expr
     } else if $lhs.is_bool() && $rhs.is_bool() {
-      fail!("cannot {} `bool`", stringify!($op))
+      #[allow(unused_variables)]
+      let $lhs = unsafe { $lhs.to_bool_unchecked() };
+      #[allow(unused_variables)]
+      let $rhs = unsafe { $rhs.to_bool_unchecked() };
+      $bool_expr
     } else if $lhs.is_none() && $rhs.is_none() {
-      fail!("cannot {} `none`", stringify!($op))
+      $none_expr
     } else if $lhs.is_object() && $rhs.is_object() {
       let $lhs = unsafe { $lhs.to_any_unchecked() };
       let $rhs = unsafe { $rhs.to_any_unchecked() };


### PR DESCRIPTION
* fix: implement `==` and `!=` for `bool` and `none` values
* fix: update the `binary!` macro to format the operator when doing arithmetic and comparison operations on `none`/`none` and `bool`/`bool` operands (used to print `"$op"`). Idk if the tests are necessary but I figured I'd put my Go experience to practice.