### PR TITLE
feat: make equality work for all combinations of values and objects

### DIFF
--- a/src/internal/object.rs
+++ b/src/internal/object.rs
@@ -272,6 +272,11 @@ declare_object_trait! {
       let this = Self::type_name(this);
       fail!("`{this}` does not support comparison")
     }
+
+    fn eq(scope, this, other: Self) -> Result<bool> {
+      let _ = scope;
+      Ok(this.ptr_eq(&other))
+    }
   }
 }
 

--- a/src/internal/object/builtin.rs
+++ b/src/internal/object/builtin.rs
@@ -59,6 +59,11 @@ impl Object for BuiltinFunction {
     todo!()
   }
 
+  fn eq(_scope: Scope<'_>, this: Ptr<Self>, other: Ptr<Self>) -> Result<bool> {
+    // This is a pointer comparison.
+    Ok(this.function.eq(&other.function))
+  }
+
   fn call(scope: Scope<'_>, this: Ptr<Self>, _: ReturnAddr) -> Result<CallResult> {
     BuiltinFunction::call(this.as_ref(), scope).map(CallResult::Return)
   }
@@ -110,6 +115,11 @@ impl Object for BuiltinAsyncFunction {
       stack_base: scope.stack_base,
       fut: BuiltinAsyncFunction::call(this.as_ref(), scope),
     }))
+  }
+
+  fn eq(_scope: Scope<'_>, this: Ptr<Self>, other: Ptr<Self>) -> Result<bool> {
+    // This is a pointer comparison.
+    Ok(this.function.eq(&other.function))
   }
 }
 
@@ -240,6 +250,14 @@ impl Object for BuiltinMethod {
 
   fn call(scope: Scope<'_>, this: Ptr<Self>, _: ReturnAddr) -> Result<CallResult> {
     BuiltinMethod::call(this.as_ref(), scope).map(CallResult::Return)
+  }
+
+  fn eq(_scope: Scope<'_>, this: Ptr<Self>, other: Ptr<Self>) -> Result<bool> {
+    // Bound methods must belong to the *same* object in memory, identified by an
+    // unaliased pointer. Therefore, their values must have the exact same
+    // representation as values, which means that we don't need to unbox them in
+    // order to compare.
+    Ok(this.this.bitwise_eq(&other.this) && this.function.eq(&other.function))
   }
 }
 

--- a/src/internal/object/list.rs
+++ b/src/internal/object/list.rs
@@ -312,6 +312,25 @@ impl Object for List {
     };
     Ok(())
   }
+
+  fn eq(scope: Scope<'_>, this: Ptr<Self>, other: Ptr<Self>) -> Result<bool> {
+    if this.len() != other.len() {
+      return Ok(false);
+    }
+
+    let this_data = this.data.borrow();
+    let other_data = other.data.borrow();
+    for i in 0..this_data.len() {
+      let lhs = this_data[i].clone();
+      let rhs = other_data[i].clone();
+      let are_equal = scope.are_equal(lhs, rhs)?;
+      if !are_equal {
+        return Ok(false);
+      }
+    }
+
+    Ok(true)
+  }
 }
 
 pub fn register_builtin_functions(global: &Global) {

--- a/src/internal/object/string.rs
+++ b/src/internal/object/string.rs
@@ -196,6 +196,10 @@ impl Object for Str {
   fn cmp(_: Scope<'_>, this: Ptr<Self>, other: Ptr<Self>) -> Result<Ordering> {
     Ok(this.as_str().cmp(other.as_str()))
   }
+
+  fn eq(_: Scope<'_>, this: Ptr<Self>, other: Ptr<Self>) -> Result<bool> {
+    Ok(this.as_str() == other.as_str())
+  }
 }
 
 pub fn register_builtin_functions(global: &Global) {

--- a/src/internal/object/table.rs
+++ b/src/internal/object/table.rs
@@ -204,6 +204,28 @@ impl Object for Table {
     this.insert(key, value);
     Ok(())
   }
+
+  fn eq(scope: Scope<'_>, this: Ptr<Self>, other: Ptr<Self>) -> Result<bool> {
+    if this.len() != other.len() {
+      return Ok(false);
+    }
+
+    let this_data = this.data.borrow();
+    let other_data = other.data.borrow();
+    for (this_key, this_value) in this_data.iter() {
+      let other_value = match other_data.get(this_key) {
+        Some(value) => value,
+        None => return Ok(false),
+      };
+
+      let are_equal = scope.are_equal(this_value.clone(), other_value.clone())?;
+      if !are_equal {
+        return Ok(false);
+      }
+    }
+
+    Ok(true)
+  }
 }
 
 declare_object_type!(Table);

--- a/src/internal/value/nanbox.rs
+++ b/src/internal/value/nanbox.rs
@@ -139,6 +139,11 @@ impl Value {
   pub fn is_object(&self) -> bool {
     self.type_tag() == ty::OBJECT
   }
+
+  #[inline]
+  pub fn bitwise_eq(&self, other: &Self) -> bool {
+    self.bits == other.bits
+  }
 }
 
 impl Clone for Value {

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__array_equality.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__array_equality.snap
@@ -1,0 +1,28 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+print [] == []
+print [1] == [1]
+print [1, 2] == [1, 2]
+print [1] != []
+print [] != [1]
+print [1, 2] != [2, 1]
+print [1, 2] != ["1", 2]
+print [to_int, to_str] == [to_int, to_str]
+
+
+# Result:
+None
+
+# Output:
+true
+true
+true
+true
+true
+true
+true
+true
+

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__heterogenous_type_equality.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__heterogenous_type_equality.snap
@@ -1,0 +1,37 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+print 1 == "0"
+print 1 == false
+print 1 == true
+print 1 == none
+print none == "string"
+print none == []
+print [] == "string"
+class Test: pass
+print Test() == "string"
+print Test() == none
+print Test() == []
+print to_str == to_int
+print Test() == to_int
+
+
+# Result:
+None
+
+# Output:
+false
+false
+false
+false
+false
+false
+false
+false
+false
+false
+false
+false
+

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__heterogenous_type_unequality.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__heterogenous_type_unequality.snap
@@ -1,0 +1,37 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+print 1 != "0"
+print 1 != false
+print 1 != true
+print 1 != none
+print none != "string"
+print none != []
+print [] != "string"
+class Test: pass
+print Test() != "string"
+print Test() != none
+print Test() != []
+print to_str != to_int
+print Test() != to_int
+
+
+# Result:
+None
+
+# Output:
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__object_equality.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__object_equality.snap
@@ -1,0 +1,35 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+print to_int == to_int
+print to_str == to_str
+print to_int != to_str
+print [].push != [].push
+x := []
+print x.push == x.push
+print x.is_empty != x.push
+print collect == collect
+print collect != to_int
+print "a" == "a"
+print "a" + "b" == "ab"
+print "a" + "b" != "ba"
+
+
+# Result:
+None
+
+# Output:
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+true
+

--- a/src/internal/vm/snapshots/hebi__internal__vm__tests__table_equality.snap
+++ b/src/internal/vm/snapshots/hebi__internal__vm__tests__table_equality.snap
@@ -1,0 +1,28 @@
+---
+source: src/internal/vm/tests.rs
+expression: snapshot
+---
+# Source:
+print {} == {}
+print {x: 3} == {x: 3}
+print {x: 3} != {x: none}
+print {x: 3} != {y: 3}
+print {x: 3} != {}
+print {x: 3} != {x: 3, y: 4}
+print {x: [1, 2]} == {x: [1, 2]}
+print {x: [1, 2]} != {x: [2, 3]}
+
+
+# Result:
+None
+
+# Output:
+true
+true
+true
+true
+true
+true
+true
+true
+

--- a/src/internal/vm/tests.rs
+++ b/src/internal/vm/tests.rs
@@ -1796,3 +1796,87 @@ check! {
     none <= none
   "#
 }
+
+check! {
+  heterogenous_type_equality,
+  r#"#!hebi
+  print 1 == "0"
+  print 1 == false
+  print 1 == true
+  print 1 == none
+  print none == "string"
+  print none == []
+  print [] == "string"
+  class Test: pass
+  print Test() == "string"
+  print Test() == none
+  print Test() == []
+  print to_str == to_int
+  print Test() == to_int
+  "#
+}
+
+check! {
+  heterogenous_type_unequality,
+  r#"#!hebi
+  print 1 != "0"
+  print 1 != false
+  print 1 != true
+  print 1 != none
+  print none != "string"
+  print none != []
+  print [] != "string"
+  class Test: pass
+  print Test() != "string"
+  print Test() != none
+  print Test() != []
+  print to_str != to_int
+  print Test() != to_int
+  "#
+}
+
+check! {
+  object_equality,
+  r#"#!hebi
+  print to_int == to_int
+  print to_str == to_str
+  print to_int != to_str
+  print [].push != [].push
+  x := []
+  print x.push == x.push
+  print x.is_empty != x.push
+  print collect == collect
+  print collect != to_int
+  print "a" == "a"
+  print "a" + "b" == "ab"
+  print "a" + "b" != "ba"
+  "#
+}
+
+check! {
+  array_equality,
+  r#"#!hebi
+    print [] == []
+    print [1] == [1]
+    print [1, 2] == [1, 2]
+    print [1] != []
+    print [] != [1]
+    print [1, 2] != [2, 1]
+    print [1, 2] != ["1", 2]
+    print [to_int, to_str] == [to_int, to_str]
+  "#
+}
+
+check! {
+  table_equality,
+  r#"#!hebi
+    print {} == {}
+    print {x: 3} == {x: 3}
+    print {x: 3} != {x: none}
+    print {x: 3} != {y: 3}
+    print {x: 3} != {}
+    print {x: 3} != {x: 3, y: 4}
+    print {x: [1, 2]} == {x: [1, 2]}
+    print {x: [1, 2]} != {x: [2, 3]}
+  "#
+}

--- a/src/internal/vm/thread/macros.rs
+++ b/src/internal/vm/thread/macros.rs
@@ -62,6 +62,7 @@ macro_rules! binary {
       any => $any_expr,
       bool => fail!("cannot `**` `bool`"),
       none => fail!("cannot `**` `none`"),
+      incompatible_types => fail!("operands must have the same type: `{}`, `{}`", $lhs, $rhs),
     })
   }};
   ($lhs:ident $op:tt $rhs:ident {
@@ -75,6 +76,7 @@ macro_rules! binary {
       any => $any_expr,
       bool => fail!("cannot `{}` `bool`", stringify!($op)),
       none => fail!("cannot `{}` `none`", stringify!($op)),
+      incompatible_types => fail!("operands must have the same type: `{}`, `{}`", $lhs, $rhs),
     })
   }};
   ($lhs:ident, $rhs:ident {
@@ -83,6 +85,7 @@ macro_rules! binary {
     any => $any_expr:expr,
     bool => $bool_expr:expr,
     none => $none_expr:expr,
+    incompatible_types => $on_different_object_types_expr:expr,
   }) => {{
     if $lhs.is_int() && $rhs.is_int() {
       let $lhs = unsafe { $lhs.to_int_unchecked() };
@@ -112,11 +115,12 @@ macro_rules! binary {
       let $lhs = unsafe { $lhs.to_any_unchecked() };
       let $rhs = unsafe { $rhs.to_any_unchecked() };
       if $lhs.ty() != $rhs.ty() {
-        fail!("operands must have the same type: `{}`, `{}`", $lhs, $rhs)
+        $on_different_object_types_expr
+      } else {
+        $any_expr
       }
-      $any_expr
     } else {
-      fail!("operands must have the same type: `{}`, `{}`", $lhs, $rhs)
+      $on_different_object_types_expr
     }
   }};
 }

--- a/src/public.rs
+++ b/src/public.rs
@@ -383,6 +383,14 @@ impl<'cx> Scope<'cx> {
   pub(crate) fn leave(mut self) {
     self.thread.truncate_stack(self.stack_base);
   }
+
+  pub(crate) fn are_equal(
+    &self,
+    lhs: crate::internal::value::Value,
+    rhs: crate::internal::value::Value,
+  ) -> Result<bool> {
+    Thread::check_equality(self.clone(), lhs, rhs)
+  }
 }
 
 impl<'cx> Global<'cx> {


### PR DESCRIPTION
At the moment, equality operations fail if the operands have different types. For example, `print none == 1` fails with 
```py
runtime error: operands must have the same type: `none`, `1`
```

In a dynamic language, it's fairly common to compare objects of different types. I think that a better approach would be to allow arbitrary equality checks, returning `false` for incompatible object types and defaulting to pointer comparison if the type is the same. Containers and other complex  types can customize the implementation by overriding `Object::eq`. 

## Summary

  * Add a new `eq()` method to the `Object` trait
  * Update the `binary!` macro with a branch for operations on
    incompatible types
  * Add a new `check_equality` method to `Thread` and call it from
    op_cmp_eq and op_cmp_neq
  * Add a new `are_equal` method to `Scope` that delegates to
    `Thread::check_equality`
  * Update the eq and neq opcode impls to call object.eq() if the
    types are the same instead of cmp, and fall back to the new incompatible_types
    branch otherwise.
  * Implement `eq` for the string, list, and table builtins

